### PR TITLE
Hey like tray

### DIFF
--- a/app/assets/stylesheets/active_tasks.scss
+++ b/app/assets/stylesheets/active_tasks.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the active_tasks controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/active_tasks_controller.rb
+++ b/app/controllers/active_tasks_controller.rb
@@ -1,0 +1,6 @@
+class ActiveTasksController < ApplicationController
+  def tray
+    @active_tasks_count = Task.active.count
+    render layout: false
+  end
+end

--- a/app/controllers/completed_tasks_controller.rb
+++ b/app/controllers/completed_tasks_controller.rb
@@ -1,5 +1,10 @@
 class CompletedTasksController < ApplicationController
-  before_action :set_task
+  before_action :set_task, except: %i[tray]
+
+  def tray
+    @completed_tasks_count = Task.completed.count
+    render layout: false
+  end
 
   def create
     @task.mark_as_completed

--- a/app/helpers/active_tasks_helper.rb
+++ b/app/helpers/active_tasks_helper.rb
@@ -1,0 +1,2 @@
+module ActiveTasksHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require("@github/include-fragment-element")
 require("./stimulus")
 
 

--- a/app/views/active_tasks/tray.html.erb
+++ b/app/views/active_tasks/tray.html.erb
@@ -1,0 +1,3 @@
+<% if @active_tasks_count > 0 %>
+  <span class="todo-count"><strong><%= @active_tasks_count %></strong> <%= "item".pluralize @active_tasks_count %> left</span>
+<% end %>

--- a/app/views/completed_tasks/tray.html.erb
+++ b/app/views/completed_tasks/tray.html.erb
@@ -1,0 +1,5 @@
+<% if @completed_tasks_count > 0 %>
+  <%= form_with(url: completed_task_cleanings_path) do |f| %>
+    <%= f.button 'Clear completed', type: 'submit', class: 'clear-completed' %>
+  <% end %>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,7 +16,8 @@
 
 <footer class="footer">
   <!-- This should be `0 items left` by default -->
-  <span class="todo-count"><strong><%= @active_tasks_count %></strong> <%= "item".pluralize @active_tasks_count %> left</span>
+  <include-fragment src="/active_tasks/tray" timeout="100">
+  </include-fragment>
   <!-- Remove this if you don't implement routing -->
   <ul class="filters">
     <li>
@@ -29,10 +30,6 @@
       <%= link_tab_filter('Completed', 'completed', @task_filter) %>
     </li>
   </ul>
-  <!-- Hidden if no completed items are left ↓ -->
-  <% if @completed_tasks_count > 0 %>
-    <%= form_with(url: completed_task_cleanings_path) do |f| %>
-      <%= f.button 'Clear completed', type: 'submit', class: 'clear-completed' %>
-    <% end %>
-  <% end %>
+  <include-fragment src="/completed_tasks/tray" timeout="100">
+  </include-fragment>
 </footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,7 @@ Rails.application.routes.draw do
   resources :tasks, except: %i[edit new show]
   resources :completed_task_cleanings, only: %i[create]
   resources :completed_tasks, only: %i[create destroy]
+
+  get 'active_tasks/tray', to: 'active_tasks#tray', as: 'active_tasks_tray'
+  get 'completed_tasks/tray', to: 'completed_tasks#tray', as: 'completed_tasks_tray'
 end

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "todo",
   "private": true,
   "dependencies": {
+    "@github/include-fragment-element": "^5.2.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,6 +845,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@github/include-fragment-element@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@github/include-fragment-element/-/include-fragment-element-5.2.0.tgz#46397245ee779e010d6abe027cc44e9cffeefb40"
+  integrity sha512-a+tXHC4cZmRO15GsmslHvLQzq2xBEj7uOaP7Tqd9nVyQDipipfHjZ8rbazqymHrJr9M2oa7OrmyGEnvX2uf4Jg==
+
 "@rails/actioncable@^6.0.0":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3.tgz#722b4b639936129307ddbab3a390f6bcacf3e7bc"


### PR DESCRIPTION
### Changed

- Changes the trays to be Hey-like (load after the page is loaded)

---

I'm only opening this one "for the record", because I didn't like the end resource. The reason was that there is a "flicking" when you are navigating (or using the app) because the trays have to always re-fetch. I didn't want to spend some time trying to debug this. I think there will probably be something like this on the new Turbolinks version (probably in November or so)